### PR TITLE
Sequelize ordering

### DIFF
--- a/src/npm/Sequelize.hx
+++ b/src/npm/Sequelize.hx
@@ -26,8 +26,8 @@ extern class Sequelize {
   function sync(?options : SyncOptions) : Promise<Sequelize>;
   //function drop(?options : DropOptions) : Promise<?>; // TODO
   //function authenticate() : Promise<?> // TODO
-  //function fn(fn : String, ...) // TODO
-  //col(col) -> Sequelize.col
+  function fn(functionName : String, args : haxe.extern.Rest<FunctionColumn>) : SequelizeFunction;
+  function col(colName : String) : FunctionColumn;
   //cast(val, type) -> Sequelize.cast
   //literal(val) -> Sequelize.literal
   //and(args) -> Sequelize.and

--- a/src/npm/sequelize/FunctionColumn.hx
+++ b/src/npm/sequelize/FunctionColumn.hx
@@ -1,0 +1,5 @@
+package npm.sequelize;
+
+extern class FunctionColumn {
+  
+}

--- a/src/npm/sequelize/Model.hx
+++ b/src/npm/sequelize/Model.hx
@@ -52,7 +52,7 @@ typedef Query = {
   ?attributes : Array<String>,
   ?paranoid : Bool,
   ?include : Array<IncludeOptions>,
-  //?order : String | Array | Sequelize.fn
+  ?order : EitherType<String, EitherType<Array<String>, EitherType<Array<Array<String>>, SequelizeFunction>>>,
   ?limit : Int,
   ?offset : Int,
   //?transaction : Transaction

--- a/src/npm/sequelize/Model.hx
+++ b/src/npm/sequelize/Model.hx
@@ -52,7 +52,7 @@ typedef Query = {
   ?attributes : Array<String>,
   ?paranoid : Bool,
   ?include : Array<IncludeOptions>,
-  ?order : EitherType<String, EitherType<Array<String>, EitherType<Array<Array<String>>, SequelizeFunction>>>,
+  ?order : EitherType<String, EitherType<Array<String>, EitherType<Array<Array<Dynamic>>, SequelizeFunction>>>,
   ?limit : Int,
   ?offset : Int,
   //?transaction : Transaction

--- a/src/npm/sequelize/SequelizeFunction.hx
+++ b/src/npm/sequelize/SequelizeFunction.hx
@@ -1,0 +1,5 @@
+package npm.sequelize;
+
+extern class SequelizeFunction {
+
+}


### PR DESCRIPTION
This adds support for ordering query results in Sequelize. You can also order included associations by using [their nested array of mixed types](https://github.com/sequelize/sequelize/pull/1299#issuecomment-45757496). The syntax is so intuitive and obvious that the code almost writes itself... :unamused: 
