### PR TITLE
Moment updates

### DIFF
--- a/src/npm/Moment.hx
+++ b/src/npm/Moment.hx
@@ -43,6 +43,12 @@ extern class Moment {
   function max(args : Rest<Moment>) : Moment;
   function min(args : Rest<Moment>) : Moment;
 
+  @:overload(function(value : String, ?unit : String, ?floatingPoint : Bool) : Float {})
+  @:overload(function(value : Float, ?unit : String, ?floatingPoint : Bool) : Float {})
+  @:overload(function(value : Date, ?unit : String, ?floatingPoint : Bool) : Float {})
+  @:overload(function(value : Array<Float>, ?unit : String, ?floatingPoint : Bool) : Float {})
+  function diff(value : Moment, ?unit : String, ?floatingPoint : Bool) : Float;
+
   // math
   @:overload(function(options : Dynamic<Float>) : Moment {})
   @:overload(function(duration : Duration) : Moment {})

--- a/src/npm/Moment.hx
+++ b/src/npm/Moment.hx
@@ -20,6 +20,14 @@ extern class Moment {
   @:overload(function(values : Array<Float>) : Void {})
   @:selfCall function new() : Void;
 
+  @:overload(function(value : Float) : Moment {})
+  @:overload(function(value : Array<Float>) : Moment {})
+  @:overload(function(value : String, ?format : String, ?locale : String, ?strict : Bool) : Moment {})
+  @:overload(function(value : String, ?formats : Array<String>, ?locale : String, ?strict : Bool) : Moment {})
+  @:overload(function(moment : Moment) : Moment {})
+  @:overload(function(date : Date) : Moment {})
+  static function utc() : Moment;
+
   function isValid() : Bool;
 
   // format

--- a/src/npm/Moment.hx
+++ b/src/npm/Moment.hx
@@ -5,7 +5,8 @@ import npm.moment.*;
 // import haxe.extern.EitherType;
 import haxe.extern.Rest;
 
-#if(!norequire) @:jsRequire("moment") #end
+#if(norequire) @:native("moment")
+#else @:jsRequire("moment") #end
 extern class Moment {
   static var ISO_8601(default, null) : String;
 


### PR DESCRIPTION
Adds support for the static `moment.utc()` method, as well as moment diffs. Also, switches to `@:native` when the `norequire` flag is used.
