### PR TITLE
Extern more interfaces

### DIFF
--- a/src/npm/lf/query/Delete.hx
+++ b/src/npm/lf/query/Delete.hx
@@ -1,6 +1,6 @@
 package npm.lf.query;
 
-interface Delete extends Builder {
+extern interface Delete extends Builder {
   function from(table : npm.lf.schema.Table) : Delete;
   function where(predicate : Predicate) : Delete;
 }

--- a/src/npm/lf/query/Insert.hx
+++ b/src/npm/lf/query/Insert.hx
@@ -1,6 +1,6 @@
 package npm.lf.query;
 
-interface Insert extends Builder {
+extern interface Insert extends Builder {
   function into(table : npm.lf.schema.Table) : Insert;
 
   @:overload(function (rows : npm.lf.Binder) : Insert {})

--- a/src/npm/lf/query/Update.hx
+++ b/src/npm/lf/query/Update.hx
@@ -1,6 +1,6 @@
 package npm.lf.query;
 
-interface Update extends Builder {
+extern interface Update extends Builder {
   function set(column : npm.lf.schema.Column, value : Dynamic) : Update;
   function where(predicate : npm.lf.Predicate) : Update;
 }

--- a/src/npm/lf/schema/Table.hx
+++ b/src/npm/lf/schema/Table.hx
@@ -4,6 +4,6 @@ interface Table {
   function as(name : String) : Table;
 
    // value is an object with keys matching column names
-  function createRow(value : Dynamic<Dynamic>) : npm.lf.Row;
+  function createRow(value : Dynamic) : npm.lf.Row;
   function getName() : String;
 }


### PR DESCRIPTION
Small fixes to get Lovefield working for real.  Don't merge this just yet... I want to get `onUpgrade` working right first. The function [here](https://github.com/abedev/npm/blob/master/src/npm/lf/schema/ConnectOptions.hx#L6) should return either a `Promise<Void>` or `Void`. I'm not sure what this should actually look like in the extern.
